### PR TITLE
F1SV2 fix

### DIFF
--- a/example.js
+++ b/example.js
@@ -52,9 +52,9 @@ function runDemo() {
         if (client.isV2()) {
             // is a F1sV2 device
             log('you are connecting a F1sV2 device. Warning: support for this version is experimental!');
-            client.notifySecurityAccess(function(raw) {
-                log('reading security access from device: ' + raw);
-            });
+            //client.notifySecurityAccess(function(raw) {
+              //  log('reading security access from device: ' + raw);
+            //});
         } else {
             log('you are connecting a F1s device (original version).');
         }

--- a/lib/client.js
+++ b/lib/client.js
@@ -614,8 +614,13 @@ const leloF1SdkWebClient = {
 
         const dispatcher = async () => {
             try {
+                this.logger.debug('WRITE1 ' + serviceUUID + ':' + charUUID);
+                await characteristic;
+                this.logger.debug('WRITE2 ' + serviceUUID + ':' + charUUID);
+                await this.sleep(50);
+                this.logger.debug('WRITE3 ' + serviceUUID + ':' + charUUID);
                 const wrote = await characteristic.handler.writeValue(value);
-                this.logger.debug('WRITE ' + serviceUUID + ':' + charUUID);
+                this.logger.debug('WRITE4 ' + serviceUUID + ':' + charUUID);
                 return wrote;
             } catch (err) {
                 this.logger.warn('error writing to service ' + serviceUUID + ' characteristic ' + charUUID, err);
@@ -710,6 +715,109 @@ const leloF1SdkWebClient = {
                 pending: 0,
             };
             const handler = setInterval(async () => {
+                if (connectStatus.pending) {
+                    this.logger.debug('checking for security access state skipped (another check is pending)');
+                    return;
+                }
+
+                this.logger.debug('checking for security access state ...');
+                connectStatus.pending++;
+
+                if (connectStatus.pending>1) {
+                    this.logger.debug('checking for security access state skipped (another check is pending)');
+                    return;
+                }
+
+                try {
+                    let securityAccess;
+                    try {
+                        securityAccess = await this.getSecurityAccess();
+                    } catch (err) {
+                        this.logger.debug('checking for security access threw error', err);
+                        //clearInterval(handler);
+                        //reject(err);
+                        return;
+                    }
+    
+                    var securityAccessStr = securityAccess.toString();
+                    this.logger.debug('checking for security access got raw value: ', securityAccessStr);
+    
+                    if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
+                        this.logger.debug('checking for security access: waiting for button press');
+                        while (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
+                            securityAccess = await this.getSecurityAccess();
+                            securityAccessStr = securityAccess.toString();
+                        }
+                        this.logger.debug('button pressed');
+                        this.logger.debug('checking for security access got raw value: ', securityAccessStr);
+
+                    } 
+
+                    this.logger.debug('checking for security access: button pressed, got password');
+                    connectStatus.buttonPressed = true;
+
+                    connectStatus.wrote = true;
+                    this.logger.debug('checking for security access: writing connection password to security access');
+                    
+                    securityAccess = await this.getSecurityAccess();
+                    securityAccessStr = securityAccess.toString();
+
+                    try {
+                        const pass = Uint8Array.of(252,37,91,35,253,75,144,44);
+                        //0xFC255B2;
+
+                        await this.setSecurityAccess(securityAccess);
+                        this.logger.debug('checking for security access: wrote connection password to security access succesfully');
+                        
+                    } catch (saWriteError) {
+                        this.logger.error('checking for security access: error writing connection password to security access', saWriteError);
+                        return;
+                    } finally {
+                        
+                    }
+
+                    securityAccess = await this.getSecurityAccess();
+                    securityAccessStr = securityAccess.toString();
+                    
+                    if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_CONFIRMED_VALUE.toString()) {
+                        this.logger.debug('checking for security access: received confirmation');
+                        clearInterval(handler);
+                        this.authorized = true;
+                        resolve(true);
+                    }
+
+                } finally {
+                    connectStatus.pending--;
+                }
+            }, 5000);
+        });
+    },
+
+
+    _waitForAuthorizationF1sV2old: function() {
+        /*
+        - The user starts the app, which starts bluetooth scanning for devices
+        - The user powers up the F1S device
+        - The app connects to the F1S device
+        - The app monitor Security Access characteristic, 
+            Initially, Security Access is set to 00.
+        - After connecting, the app shows a message to the user, 
+            prompting them to press the power button again
+        - After Security Access is set to a certain String 
+            (that is the password of connecting F1S) rather than the default(00)
+        - Write the String(password) into Security Access characteristic. 
+            If password is correct then the Security Access characteristic is set to 01. 
+            the app continues operation.
+        */
+        return new Promise((resolve, reject) => {
+            const attemptNum = this._currentConnectionAttempt;
+            const connectStatus = {
+                buttonPressed: false,
+                writing: 0,
+                wrote: false,
+                pending: 0,
+            };
+            const handler = setInterval(async () => {
                 //if (connectStatus.pending) {
                 //    this.logger.debug('checking for security access state skipped (another check is pending)');
                 //    return;
@@ -758,26 +866,30 @@ const leloF1SdkWebClient = {
                         connectStatus.buttonPressed = true;
     
                         setTimeout(async () => {
-                            if (!connectStatus.wrote && !connectStatus.writing) {
-                                connectStatus.writing++;
+                            if (!connectStatus.wrote) {
+                                connectStatus.wrote = true;
                                 this.logger.debug('checking for security access: writing connection password to security access');
                                 
                                 try {
-                                    await this.setSecurityAccess(securityAccess);
+                                    const pass = Uint8Array.of(252,37,91,35,253,75,144,44);
+                                    //const pass = 0xFC255B2;
+
+
+                                    await this.setSecurityAccess(pass);
                                     this.logger.debug('checking for security access: wrote connection password to security access succesfully');
-                                    connectStatus.wrote = true;
+                                    
                                 } catch (saWriteError) {
                                     this.logger.error('checking for security access: error writing connection password to security access', saWriteError);
                                 } finally {
-                                    connectStatus.writing--;
+                                    
                                 }
                             }
-                        }, 10000);
+                        }, 5000);
                     }
                 } finally {
                     connectStatus.pending--;
                 }
-            }, 500);
+            }, 5000);
         });
     },
 
@@ -869,20 +981,13 @@ const leloF1SdkWebClient = {
     setSecurityAccess: async function(bytes) {
         this._requireProtocol(2);
         this.logger.debug('writing security access input:' + bytes);
-        const payload = Uint8Array.of(
+        let payload = Uint8Array.of(
             bytes[0], bytes[1], bytes[2], bytes[3],
             bytes[4], bytes[5], bytes[6], bytes[7]
         );
         this.logger.debug('writing security access payload:' + payload);
-        await this.sleep(1000);
-        var result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
-        await result;
-        //do {
-            this.logger.debug('security access payload written ' + result.status);
-            //sleep(1000);
-            //result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, false);
-        //} while(!result);
-        return result;
+        await this.sleep(400);
+        return this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, true);
     },
 
     setMotorsSpeed: async function(motorSpeed, vibeSpeed) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -614,13 +614,8 @@ const leloF1SdkWebClient = {
 
         const dispatcher = async () => {
             try {
-                this.logger.debug('WRITE1 ' + serviceUUID + ':' + charUUID);
-                await characteristic;
-                this.logger.debug('WRITE2 ' + serviceUUID + ':' + charUUID);
-                await this.sleep(50);
-                this.logger.debug('WRITE3 ' + serviceUUID + ':' + charUUID);
                 const wrote = await characteristic.handler.writeValue(value);
-                this.logger.debug('WRITE4 ' + serviceUUID + ':' + charUUID);
+                this.logger.debug('WRITE ' + serviceUUID + ':' + charUUID);
                 return wrote;
             } catch (err) {
                 this.logger.warn('error writing to service ' + serviceUUID + ' characteristic ' + charUUID, err);
@@ -715,109 +710,6 @@ const leloF1SdkWebClient = {
                 pending: 0,
             };
             const handler = setInterval(async () => {
-                if (connectStatus.pending) {
-                    this.logger.debug('checking for security access state skipped (another check is pending)');
-                    return;
-                }
-
-                this.logger.debug('checking for security access state ...');
-                connectStatus.pending++;
-
-                if (connectStatus.pending>1) {
-                    this.logger.debug('checking for security access state skipped (another check is pending)');
-                    return;
-                }
-
-                try {
-                    let securityAccess;
-                    try {
-                        securityAccess = await this.getSecurityAccess();
-                    } catch (err) {
-                        this.logger.debug('checking for security access threw error', err);
-                        //clearInterval(handler);
-                        //reject(err);
-                        return;
-                    }
-    
-                    var securityAccessStr = securityAccess.toString();
-                    this.logger.debug('checking for security access got raw value: ', securityAccessStr);
-    
-                    if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
-                        this.logger.debug('checking for security access: waiting for button press');
-                        while (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
-                            securityAccess = await this.getSecurityAccess();
-                            securityAccessStr = securityAccess.toString();
-                        }
-                        this.logger.debug('button pressed');
-                        this.logger.debug('checking for security access got raw value: ', securityAccessStr);
-
-                    } 
-
-                    this.logger.debug('checking for security access: button pressed, got password');
-                    connectStatus.buttonPressed = true;
-
-                    connectStatus.wrote = true;
-                    this.logger.debug('checking for security access: writing connection password to security access');
-                    
-                    securityAccess = await this.getSecurityAccess();
-                    securityAccessStr = securityAccess.toString();
-
-                    try {
-                        const pass = Uint8Array.of(252,37,91,35,253,75,144,44);
-                        //0xFC255B2;
-
-                        await this.setSecurityAccess(securityAccess);
-                        this.logger.debug('checking for security access: wrote connection password to security access succesfully');
-                        
-                    } catch (saWriteError) {
-                        this.logger.error('checking for security access: error writing connection password to security access', saWriteError);
-                        return;
-                    } finally {
-                        
-                    }
-
-                    securityAccess = await this.getSecurityAccess();
-                    securityAccessStr = securityAccess.toString();
-                    
-                    if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_CONFIRMED_VALUE.toString()) {
-                        this.logger.debug('checking for security access: received confirmation');
-                        clearInterval(handler);
-                        this.authorized = true;
-                        resolve(true);
-                    }
-
-                } finally {
-                    connectStatus.pending--;
-                }
-            }, 5000);
-        });
-    },
-
-
-    _waitForAuthorizationF1sV2old: function() {
-        /*
-        - The user starts the app, which starts bluetooth scanning for devices
-        - The user powers up the F1S device
-        - The app connects to the F1S device
-        - The app monitor Security Access characteristic, 
-            Initially, Security Access is set to 00.
-        - After connecting, the app shows a message to the user, 
-            prompting them to press the power button again
-        - After Security Access is set to a certain String 
-            (that is the password of connecting F1S) rather than the default(00)
-        - Write the String(password) into Security Access characteristic. 
-            If password is correct then the Security Access characteristic is set to 01. 
-            the app continues operation.
-        */
-        return new Promise((resolve, reject) => {
-            const attemptNum = this._currentConnectionAttempt;
-            const connectStatus = {
-                buttonPressed: false,
-                writing: 0,
-                wrote: false,
-                pending: 0,
-            };
-            const handler = setInterval(async () => {
                 //if (connectStatus.pending) {
                 //    this.logger.debug('checking for security access state skipped (another check is pending)');
                 //    return;
@@ -866,30 +758,26 @@ const leloF1SdkWebClient = {
                         connectStatus.buttonPressed = true;
     
                         setTimeout(async () => {
-                            if (!connectStatus.wrote) {
-                                connectStatus.wrote = true;
+                            if (!connectStatus.wrote && !connectStatus.writing) {
+                                connectStatus.writing++;
                                 this.logger.debug('checking for security access: writing connection password to security access');
                                 
                                 try {
-                                    const pass = Uint8Array.of(252,37,91,35,253,75,144,44);
-                                    //const pass = 0xFC255B2;
-
-
-                                    await this.setSecurityAccess(pass);
+                                    await this.setSecurityAccess(securityAccess);
                                     this.logger.debug('checking for security access: wrote connection password to security access succesfully');
-                                    
+                                    connectStatus.wrote = true;
                                 } catch (saWriteError) {
                                     this.logger.error('checking for security access: error writing connection password to security access', saWriteError);
                                 } finally {
-                                    
+                                    connectStatus.writing--;
                                 }
                             }
-                        }, 5000);
+                        }, 10000);
                     }
                 } finally {
                     connectStatus.pending--;
                 }
-            }, 5000);
+            }, 500);
         });
     },
 
@@ -981,13 +869,20 @@ const leloF1SdkWebClient = {
     setSecurityAccess: async function(bytes) {
         this._requireProtocol(2);
         this.logger.debug('writing security access input:' + bytes);
-        let payload = Uint8Array.of(
+        const payload = Uint8Array.of(
             bytes[0], bytes[1], bytes[2], bytes[3],
             bytes[4], bytes[5], bytes[6], bytes[7]
         );
         this.logger.debug('writing security access payload:' + payload);
-        await this.sleep(400);
-        return this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, true);
+        await this.sleep(1000);
+        var result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
+        await result;
+        //do {
+            this.logger.debug('security access payload written ' + result.status);
+            //sleep(1000);
+            //result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, false);
+        //} while(!result);
+        return result;
     },
 
     setMotorsSpeed: async function(motorSpeed, vibeSpeed) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -710,10 +710,10 @@ const leloF1SdkWebClient = {
                 pending: 0,
             };
             const handler = setInterval(async () => {
-                //if (connectStatus.pending) {
-                //    this.logger.debug('checking for security access state skipped (another check is pending)');
-                //    return;
-                //}
+                if (connectStatus.pending) {
+                    this.logger.debug('checking for security access state skipped (another check is pending)');
+                    return;
+                }
 
                 if (this._currentConnectionAttempt !== attemptNum || this.disposing) {
                     this.logger.debug('checking for security access state aborted (obsolete connection attempt)');
@@ -735,17 +735,11 @@ const leloF1SdkWebClient = {
                         return;
                     }
     
-                    var securityAccessStr = securityAccess.toString();
+                    const securityAccessStr = securityAccess.toString();
                     this.logger.debug('checking for security access got raw value: ', securityAccessStr);
     
                     if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
                         this.logger.debug('checking for security access: waiting for button press');
-                        while (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
-                            securityAccess = await this.getSecurityAccess();
-                            securityAccessStr = securityAccess.toString();
-                        }
-                        this.logger.debug('button pressed');
-                        this.logger.debug('checking for security access got raw value: ', securityAccessStr);
 
                     } else if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_CONFIRMED_VALUE.toString()) {
                         this.logger.debug('checking for security access: received confirmation');
@@ -772,7 +766,7 @@ const leloF1SdkWebClient = {
                                     connectStatus.writing--;
                                 }
                             }
-                        }, 10000);
+                        }, 500);
                     }
                 } finally {
                     connectStatus.pending--;
@@ -862,11 +856,7 @@ const leloF1SdkWebClient = {
         return value.getUint8(2);
     },
 
-    sleep: function(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-    },
-
-    setSecurityAccess: async function(bytes) {
+    setSecurityAccess: function(bytes) {
         this._requireProtocol(2);
         this.logger.debug('writing security access input:' + bytes);
         const payload = Uint8Array.of(
@@ -874,15 +864,7 @@ const leloF1SdkWebClient = {
             bytes[4], bytes[5], bytes[6], bytes[7]
         );
         this.logger.debug('writing security access payload:' + payload);
-        await this.sleep(1000);
-        var result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
-        await result;
-        //do {
-            this.logger.debug('security access payload written ' + result.status);
-            //sleep(1000);
-            //result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, false);
-        //} while(!result);
-        return result;
+        return this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
     },
 
     setMotorsSpeed: async function(motorSpeed, vibeSpeed) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -710,10 +710,10 @@ const leloF1SdkWebClient = {
                 pending: 0,
             };
             const handler = setInterval(async () => {
-                if (connectStatus.pending) {
-                    this.logger.debug('checking for security access state skipped (another check is pending)');
-                    return;
-                }
+                //if (connectStatus.pending) {
+                //    this.logger.debug('checking for security access state skipped (another check is pending)');
+                //    return;
+                //}
 
                 if (this._currentConnectionAttempt !== attemptNum || this.disposing) {
                     this.logger.debug('checking for security access state aborted (obsolete connection attempt)');
@@ -735,11 +735,17 @@ const leloF1SdkWebClient = {
                         return;
                     }
     
-                    const securityAccessStr = securityAccess.toString();
+                    var securityAccessStr = securityAccess.toString();
                     this.logger.debug('checking for security access got raw value: ', securityAccessStr);
     
                     if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
                         this.logger.debug('checking for security access: waiting for button press');
+                        while (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_INIT_VALUE.toString()) {
+                            securityAccess = await this.getSecurityAccess();
+                            securityAccessStr = securityAccess.toString();
+                        }
+                        this.logger.debug('button pressed');
+                        this.logger.debug('checking for security access got raw value: ', securityAccessStr);
 
                     } else if (securityAccessStr === leloF1SdkDeviceDefinitions.SECURITY_ACCESS_CONFIRMED_VALUE.toString()) {
                         this.logger.debug('checking for security access: received confirmation');
@@ -766,7 +772,7 @@ const leloF1SdkWebClient = {
                                     connectStatus.writing--;
                                 }
                             }
-                        }, 500);
+                        }, 10000);
                     }
                 } finally {
                     connectStatus.pending--;
@@ -856,7 +862,11 @@ const leloF1SdkWebClient = {
         return value.getUint8(2);
     },
 
-    setSecurityAccess: function(bytes) {
+    sleep: function(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    },
+
+    setSecurityAccess: async function(bytes) {
         this._requireProtocol(2);
         this.logger.debug('writing security access input:' + bytes);
         const payload = Uint8Array.of(
@@ -864,7 +874,15 @@ const leloF1SdkWebClient = {
             bytes[4], bytes[5], bytes[6], bytes[7]
         );
         this.logger.debug('writing security access payload:' + payload);
-        return this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
+        await this.sleep(1000);
+        var result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload);
+        await result;
+        //do {
+            this.logger.debug('security access payload written ' + result.status);
+            //sleep(1000);
+            //result = this._write(leloF1SdkDeviceDefinitions.LELO_SERVICE, leloF1SdkDeviceDefinitions.SECURITY_ACCESS, payload, false);
+        //} while(!result);
+        return result;
     },
 
     setMotorsSpeed: async function(motorSpeed, vibeSpeed) {


### PR DESCRIPTION
When I tested with my F1SV2 on MacOS and Windows with chrome I had initially a "GATT NotSupportedError when writing code 9" when the password was written to the SecurityAccess characteristic. I found that by the notification registration to the SecurityAccess characteristic the issue disappeared whiteout affecting much the functionalities since this was there essentially for debug purpose